### PR TITLE
Fixes/enhancements to python bindings sdist generation

### DIFF
--- a/bindings/python/.gitignore
+++ b/bindings/python/.gitignore
@@ -3,3 +3,5 @@ build
 .pydevproject
 .cproject
 *.py[co]
+MANIFEST
+VERSION_INFO

--- a/bindings/python/MANIFEST.in
+++ b/bindings/python/MANIFEST.in
@@ -1,6 +1,5 @@
 include README.rst
 include VERSION_INFO
-include genversion.sh
 recursive-include tests *
 recursive-include examples *.py
 recursive-include docs *

--- a/bindings/python/README.rst
+++ b/bindings/python/README.rst
@@ -1,0 +1,16 @@
+Prerequisites (incomplete): xrootd
+
+# Installing on OSX
+Setup should succeed if:
+ - xrootd is installed on your system
+ - xrootd was installed via homebrew
+ - you're installing the bindings package with the same version number as the
+   xrootd installation (`xrootd -v`).
+
+If you have xrootd installed and the installation still fails, do
+`XRD_LIBDIR=XYZ; XRD_INCDIR=ZYX; pip install xrootd`
+where XYZ and ZYX are the paths to the XRootD library and include directories on your system.
+
+## How to find the lib and inc directories
+To find the library directory, search your system for "libXrd*" files.
+The include directory should contain a file named "XrdVersion.hh", so search for that.

--- a/bindings/python/setup_pypi.py
+++ b/bindings/python/setup_pypi.py
@@ -23,10 +23,8 @@ xrdlibdir = getenv( 'XRD_LIBDIR' ) or '/usr/lib'
 xrdincdir = getenv( 'XRD_INCDIR' ) or '/usr/include/xrootd'
 
 # Get package version
-topdir = path.dirname(path.dirname(getcwd()))
-p = subprocess.Popen(['./genversion.sh', '--print-only'], stdout=subprocess.PIPE, cwd=topdir)
-version, err = p.communicate()
-version = version.strip()
+with open ('VERSION_INFO') as verfile:
+    version = verfile.read().strip()
 
 print 'XRootD library dir: ', xrdlibdir
 print 'XRootD include dir: ', xrdincdir

--- a/bindings/python/setup_pypi.py
+++ b/bindings/python/setup_pypi.py
@@ -1,6 +1,7 @@
 from distutils.core import setup, Extension
 from distutils import sysconfig
 from os import getenv, walk, path, path, getcwd, chdir
+from platform import system
 import subprocess
 
 # Remove the "-Wstrict-prototypes" compiler option, which isn't valid for C++.
@@ -19,12 +20,22 @@ for dirname, dirnames, filenames in walk('src'):
     elif filename.endswith('.hh'):
       depends.append(path.join(dirname, filename))
 
-xrdlibdir = getenv( 'XRD_LIBDIR' ) or '/usr/lib'
-xrdincdir = getenv( 'XRD_INCDIR' ) or '/usr/include/xrootd'
-
 # Get package version
 with open ('VERSION_INFO') as verfile:
     version = verfile.read().strip()
+
+def getincdir_osx():
+    # Assume xrootd was installed via homebrew
+    return '/usr/local/Cellar/xrootd/{0}/include/xrootd'.format(version)
+
+def getlibdir():
+    return (system() == 'Darwin' and '/usr/local/lib') or '/usr/lib'
+
+def getincdir():
+    return (system() == 'Darwin' and getincdir_osx()) or '/usr/include/xrootd'
+
+xrdlibdir = getenv( 'XRD_LIBDIR' ) or getlibdir()
+xrdincdir = getenv( 'XRD_INCDIR' ) or getincdir()
 
 print 'XRootD library dir: ', xrdlibdir
 print 'XRootD include dir: ', xrdincdir

--- a/dopy.sh
+++ b/dopy.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Writes the xrootd version to bindings/python/VERSION_INFO,
+# generates and uploads a source distribution for the python bindings.
+./genversion.sh --print-only | sed "s/v//" > bindings/python/VERSION_INFO
+cd bindings/python
+cp setup_pypi.py setup.py
+python setup.py sdist
+twine upload dist/*
+rm setup.py dist/*
+


### PR DESCRIPTION
- Adds a bash script that generates and uploads the python source distribution for the bindings to PyPi. This replaces the "tox script" due to limitations with tox.
- Adds (some) support for OSX for the python bindings
